### PR TITLE
Allow ignore of directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ For more control over the parsing and conversion process, a `.zod/config` file c
 
     [ignore]
     Makefile
+    .hide/
 
 Here we're only parsing (not converting to a different format) files matching `*.htm` and `*.html`.
 
@@ -180,7 +181,7 @@ Files matching `*.md` are going to be parsed and converted using the `smu` markd
 
 Files matching `*.txt` are going to be parsed and converted using `asciidoc`.
 
-Files matching `Makefile` will be ignored and not copied.
+Files matching `Makefile` and directories matching `.hide` will be ignored and not copied.
 
 Conversion programs must accept a UNIX-style pipe and send converted data to stdout.
 

--- a/bin/zod-internal
+++ b/bin/zod-internal
@@ -11,7 +11,8 @@ helpers.awk
 *.partial
 *.layout
 *.meta
-config
+.zod/
+.git/
 !
 }
 

--- a/lib/config.awk
+++ b/lib/config.awk
@@ -34,5 +34,9 @@ action == "config" && section == "parse_convert" && (NF > 1) {
 }
 
 action == "config" && section == "ignore" {
-  ignore[ignore_count++] = $0
+  if (substr($0, length($0)) == "/") {
+    ignore_dir[ignore_dir_count++] = substr($0, 1, length($0) - 1)
+  } else {
+    ignore[ignore_count++] = $0
+  }
 }

--- a/lib/find_cmd.awk
+++ b/lib/find_cmd.awk
@@ -23,8 +23,15 @@ END {
       opts[opt_count++] = exts[i]
     }
   }
+  if ( length(ignore_dir) ) {
+    prunepart = "-type d \\( -name \"" ignore_dir[0] "\""
+    for (i = 1; i < length(ignore_dir); i++) {
+      prunepart = prunepart " -o -name \"" ignore_dir[i] "\""
+    }
+    prunepart = prunepart " \\) -prune -o"
+  }
   for (i = 0; i < length(opts); i++) {
     optpart = optpart " " opts[i]
   }
-  printf "find \"%s\" -type f \\( %s \\) -exec zod-%s \"%s\" \"%s\" \"%s\" {} \\;", proj, optpart, phase, zod_lib, proj, target
+  printf "find \"%s\" %s -type f \\( %s \\) -exec zod-%s \"%s\" \"%s\" \"%s\" {} \\;", proj, prunepart, optpart, phase, zod_lib, proj, target
 }


### PR DESCRIPTION
Before this commit, any line under the `[ignore]` section of `.zod/config` matched only filenames, not directory names.  This commit allows the user to indicate whole directories to ignore.  The user does
this by ending the name spec with `/`.

For instance, using the snippet

```
[ignore]
Makefile
.hide/
```

in `.zod/config` will cause zod to ignore files matching `Makefile` and directories matching `.hide`.

Additionally, directories matching `.zod` and `.git` are already ignored by default (as a convenience to the user).