### PR TITLE
find location for emph closing tag

### DIFF
--- a/lib/markdown.awk
+++ b/lib/markdown.awk
@@ -120,7 +120,7 @@ BEGIN {
 /\*\*/ {
 	while (match($0, /\*\*/) != 0) {
 		if (env == "emph") {
-			sub(//, "</emph>");
+			sub(/\*\*/, "</emph>");
 			env = peenv;
 		}
 		else {


### PR DESCRIPTION
The code in markdown.awk didn´t  find the second correct location where to place `</emph>`

With this fix:
`**foo** bar`
 
will be:

`<emph>foo</emph> bar`