### PR TITLE
Added multicore processing and "only update changed files" feature

### DIFF
--- a/bin/zod-internal
+++ b/bin/zod-internal
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 __zod_config() {
+  [ -e "$proj/.zod/state" ] || touch -t 197001010000 "$proj/.zod/state"
   cat - "$proj/.zod/config" <<! 2>/dev/null
 [parse]
 htm,html

--- a/bin/zod.template
+++ b/bin/zod.template
@@ -23,6 +23,7 @@ _zod_exec() {
       -v zod_lib="$zod_lib" \
       -v proj="$proj" \
       -v target="$target" | sh
+  touch "$proj/.zod/state"
 }
 
 [ "$#" -ne 2 ] && { echo "usage: zod projectdir targetdir"; exit; }

--- a/lib/find_cmd.awk
+++ b/lib/find_cmd.awk
@@ -1,6 +1,12 @@
 BEGIN {
   section = "none"
   action = "config"
+  if (system("which nproc > /dev/null") == 0) {
+	  "nproc --all" | getline procs
+	  procs = procs
+  } else {
+	  procs = 1
+  }
 }
 
 END {
@@ -26,5 +32,6 @@ END {
   for (i = 0; i < length(opts); i++) {
     optpart = optpart " " opts[i]
   }
-  printf "find \"%s\" -type f \\( %s \\) -exec zod-%s \"%s\" \"%s\" \"%s\" {} \\;", proj, optpart, phase, zod_lib, proj, target
+  printf "find \"%s\" -type f -cnewer \"%s/.zod/state\" \\( %s \\) -print0 | xargs -0 -P %s -I {} zod-%s \"%s\" \"%s\" \"%s\" {} \\;",
+	  proj, proj, optpart, procs, phase, zod_lib, proj, target
 }


### PR DESCRIPTION
The title pretty much says it. I implemented these two features because the markdown client I'm using (pandoc) can be pretty slow from time to time, so I'd rather not that all every file is re-rendered all the time. Multiprocessing is practically a `make -jN` ripoff, but currently it just defaults to the number of cores, if `nproc` is found, otherwise it just runs everything sequentially.

If you have any problem with any of these changed, feel free to tell me, because to my knowledge, zodiac would be the only simple web-framework to support these features with the amount of flexibility offered, and I guess that others would also appropriate it.